### PR TITLE
WIP: when ref.uri is empty but node-Id exists. Use it. 

### DIFF
--- a/lib/signed-xml.js
+++ b/lib/signed-xml.js
@@ -557,13 +557,16 @@ SignedXml.prototype.createReferences = function(doc, prefix) {
       if (!nodes.hasOwnProperty(h)) continue;
 
       var node = nodes[h]
-      if (ref.isEmptyUri) {
-        res += "<" + prefix + "Reference URI=\"\">"
+      if (!ref.isEmptyUri) {
+        res += "<" + prefix + "Reference URI=\"" + ref.uri + "\">"
       }
-      else {
+      else if (this.ensureHasId(node)) {
         var id = this.ensureHasId(node);
         ref.uri = id
         res += "<" + prefix + "Reference URI=\"#" + id + "\">"
+      }
+      else {
+        res += "<" + prefix + "Reference URI=\"\">"
       }
       res += "<" + prefix + "Transforms>"
       for (var t in ref.transforms) {


### PR DESCRIPTION
We were having issues with an empty Reference URI since the code block with the `id` check only works when there is a URI. 
